### PR TITLE
use a CSV parser to parse CSV

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,8 +68,9 @@ func main() {
 			continue
 		}
 		talk, _ := getTalk(data[0])
+		talk.Duration = data[7]
 		person, _ := getPerson(talk.PersonID)
-		fmt.Printf("%s,\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n", csvFriendlify(talk.ID), csvFriendlify(talk.Title), csvFriendlify(talk.Subtitle), csvFriendlify(talk.Abstract), csvFriendlify(talk.Description), csvFriendlify(talk.Notes), csvFriendlify(data[7]), csvFriendlify(talk.State), csvFriendlify(talk.Progress), csvFriendlify(person.FirstName), csvFriendlify(person.Email))
+		fmt.Printf("%s,\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\",\"%s\"\n", csvFriendlify(talk.ID), csvFriendlify(talk.Title), csvFriendlify(talk.Subtitle), csvFriendlify(talk.Abstract), csvFriendlify(talk.Description), csvFriendlify(talk.Notes), csvFriendlify(talk.Duration), csvFriendlify(talk.State), csvFriendlify(talk.Progress), csvFriendlify(person.FirstName), csvFriendlify(person.Email))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/csv"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -52,15 +54,23 @@ func main() {
 		config.PentaURL = "https://penta.fosdem.org"
 	}
 
-	csv, err := getCSV()
+	csvdata, err := getCSV()
 	if err != nil {
 		log.Fatal(err.Error())
 		os.Exit(1)
 	}
 
 	fmt.Println("ID,Title,Subtitle,Abstract,Description,Notes,Duration,State,Progress")
-	for _, line := range strings.Split(string(csv), "\n") {
-		data := strings.Split(line, ",")
+	r := csv.NewReader(strings.NewReader(string(csvdata[:])))
+	for {
+		data, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		if len(data) < 2 { // invalid line
 			continue
 		}


### PR DESCRIPTION
Our 2020 FOSDEM devroom (DNS, `PENTA_DEVROOM_ID=758`) has two talks with a comma in their title. This breaks with the existing code, shifting columns such that the Duration disappears.

This PR switches to the CSV parser that ships with Go. On our devroom, this does not change the tool output except for the two rooms with a comma in their title. Those now get their duration in the right column.